### PR TITLE
Make Dir#each deterministic

### DIFF
--- a/lib/sequel/extensions/migration.rb
+++ b/lib/sequel/extensions/migration.rb
@@ -402,7 +402,7 @@ module Sequel
     # after 2005, otherwise uses the IntegerMigrator.
     def self.migrator_class(directory)
       if self.equal?(Migrator)
-        Dir.new(directory).each do |file|
+        Dir.new(directory).sort.each do |file|
           next unless MIGRATION_FILE_PATTERN.match(file)
           return TimestampMigrator if file.split(MIGRATION_SPLITTER, 2).first.to_i > MINIMUM_TIMESTAMP
         end
@@ -559,7 +559,7 @@ module Sequel
     # Returns any found migration files in the supplied directory.
     def get_migration_files
       files = []
-      Dir.new(directory).each do |file|
+      Dir.new(directory).sort.each do |file|
         next unless MIGRATION_FILE_PATTERN.match(file)
         version = migration_version_from_file(file)
         if version >= 20000101
@@ -702,7 +702,7 @@ module Sequel
     # Returns any migration files found in the migrator's directory.
     def get_migration_files
       files = []
-      Dir.new(directory).each do |file|
+      Dir.new(directory).sort.each do |file|
         next unless MIGRATION_FILE_PATTERN.match(file)
         files << File.join(directory, file)
       end


### PR DESCRIPTION
Dir#each can return entries in different order on different systems. Make the order deterministic by sorting entries first.
An example of the problem: two timestamped migrations with the same timestamp could be applied in different order on development and production.